### PR TITLE
Add basic Windows support

### DIFF
--- a/cmd/localias/debug/cert.go
+++ b/cmd/localias/debug/cert.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/spf13/cobra"
 
 	"github.com/peterldowns/localias/cmd/localias/shared"
+	"github.com/peterldowns/localias/pkg/windows"
 	"github.com/peterldowns/localias/pkg/wsl"
 )
 
@@ -29,7 +31,14 @@ func certImpl(_ *cobra.Command, _ []string) error {
 		fmt.Println(string(content))
 	}
 	if *certFlags.Install {
-		if err := wsl.InstallCert(rootCrtPath); err != nil {
+		var err error
+		switch runtime.GOOS {
+		case "windows":
+			err = windows.InstallCert(rootCrtPath)
+		default:
+			err = wsl.InstallCert(rootCrtPath)
+		}
+		if err != nil {
 			return err
 		}
 	}

--- a/cmd/localias/hostctl/path.go
+++ b/cmd/localias/hostctl/path.go
@@ -32,6 +32,8 @@ func getPaths(hctl hostctl.Controller) []string {
 	switch c := hctl.(type) {
 	case *hostctl.FileController:
 		return []string{c.Path}
+	case *hostctl.WindowsController:
+		return []string{c.WindowsHostsFile}
 	case *hostctl.WSLController:
 		return []string{
 			// TODO: extract to a constant and a helper for getting the unix

--- a/cmd/localias/shared/shared.go
+++ b/cmd/localias/shared/shared.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/peterldowns/localias/pkg/config"
 	"github.com/peterldowns/localias/pkg/hostctl"
+	"github.com/peterldowns/localias/pkg/windows"
 	"github.com/peterldowns/localias/pkg/wsl"
 )
 
@@ -29,12 +30,19 @@ func Config() *config.Config {
 
 func Controller() hostctl.Controller {
 	name := "localias"
+
+	// On Windows, always edit the Windows hosts file
+	if windows.IsWindows() {
+		return hostctl.NewWindowsController(name)
+	}
+
 	// On WSL/Mac/Linux, we're always going to need to edit /etc/hosts.
 	etcHostController := hostctl.NewFileController(
 		"/etc/hosts",
 		true,
 		name,
 	)
+
 	// If we're on WSL, we'll also need to update the window machine's
 	// host file.
 	if wsl.IsWSL() {
@@ -44,6 +52,7 @@ func Controller() hostctl.Controller {
 			etcHostController,
 		)
 	}
+
 	return etcHostController
 }
 

--- a/pkg/hostctl/windows.go
+++ b/pkg/hostctl/windows.go
@@ -1,0 +1,89 @@
+package hostctl
+
+import (
+	"fmt"
+	"os"
+)
+
+type WindowsController struct {
+	FileController
+	WindowsHostsFile string
+}
+
+// NewWindowsController creates a new [WindowsController]. It can be used when
+// localias is ran on Windows (GOOS=windows). Contents for the hosts file are first
+// written to a temporary file and then compared to contain changes. If there are
+// changes, the actual Windows hosts file is modified. This is the same model the
+// WSLController uses, except for WSL specific PowerShell script invocations.
+func NewWindowsController(name string) *WindowsController {
+	x := WindowsController{}
+	x.WindowsHostsFile = os.Getenv("SystemRoot") + `\System32\drivers\etc\hosts`
+
+	// TODO: don't panic in this code, but return an error instead? But it's
+	// the pattern that's in use, and seems to be used for error handling too.
+	tmpfile, err := os.CreateTemp("", fmt.Sprintf("%s-hosts-*", name))
+	if err != nil {
+		panic(err)
+	}
+	defer tmpfile.Close()
+
+	contents, err := os.ReadFile(x.WindowsHostsFile)
+	if err != nil {
+		panic(err)
+	}
+	if _, err := tmpfile.Write([]byte(contents)); err != nil {
+		panic(err)
+	}
+
+	x.FileController = FileController{
+		Path: tmpfile.Name(),
+		Sudo: true, // always needs administrator permissions
+		Name: name,
+	}
+
+	return &x
+}
+
+func (w *WindowsController) Set(ip string, alias string) error {
+	return w.FileController.Set(ip, alias)
+}
+
+func (w *WindowsController) SetLocal(alias string) error {
+	return w.FileController.Set("127.0.0.1", alias)
+}
+
+func (w *WindowsController) Remove(alias string) error {
+	return w.FileController.Remove(alias)
+}
+
+func (w *WindowsController) Clear() error {
+	return w.FileController.Clear()
+}
+
+func (w *WindowsController) Apply() (bool, error) {
+	changes, err := w.FileController.Apply()
+	if err != nil {
+		return false, err
+	}
+	if changes {
+		// read the current state of the temporary file after changes
+		// were detected.
+		contents, err := os.ReadFile(w.FileController.Path)
+		if err != nil {
+			return false, err
+		}
+
+		// TODO(hs): use PowerShell instead, similar to the WSL implementation, so that similar errors
+		// are reported and can be handled in a unified way?
+		if err := os.WriteFile(w.WindowsHostsFile, contents, 0o644); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+	return false, nil
+}
+
+func (w *WindowsController) List() (map[string][]*Line, error) {
+	return w.FileController.List()
+}

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -1,0 +1,20 @@
+package windows
+
+import (
+	"errors"
+	"runtime"
+)
+
+func IsWindows() bool {
+	return runtime.GOOS == "windows"
+}
+
+func InstallCert(certPath string) error {
+	_, err := powershell("scripts/install-cert.ps1", certPath)
+	return err
+}
+
+func powershell(scriptPath string, args ...string) (string, error) {
+	_, _ = scriptPath, args
+	return "", errors.New("not implemented") // TODO(hs): implement this with PowerShell invocation too?
+}


### PR DESCRIPTION
This PR adds support for running `localias` on native Windows. The Windows hosts file is determined relative from the `SystemRoot` environment variable. Changes to the hosts file are written in a similar manner as the WSL implementation.

@peterldowns I'm curious if you would like this to (re)use the PowerShell scripts, for both installing the root cert, as well as writing the actual hosts file, so that it works similar to the WSL implementation. If so, I might move the scripts around a bit, so that they can be used by both packages.

Haven't tested all functionalities yet, but the basics seem to work. ~The admin socket may need some scrutiny, as using `localias.exe run` and then using `ctrl-c` to quit, leaves the socket in place.~ Probably just needs some cleanup at the end of the `run` loop (and/or force some cleanup if not already running, similar to how a new daemon is not started if it's already running).

