### PR TITLE
feat(caddy): support origin header override

### DIFF
--- a/pkg/config/example.roundtrip.yaml
+++ b/pkg/config/example.roundtrip.yaml
@@ -1,15 +1,17 @@
 # localias config file syntax
 #
-# 	alias: port
+# 	alias: port/optional origin schema
 #
 # for example,
 #
 #   bareTLD: 9003 # serves over https and http
+#   bareTLD: 9003/http # same as above but Origin header is set to http schema
 #   implicitly_secure.test: 9002 # serves over https and http
 #   https://explicit_secure.test: 9000 # serves over https and http
 #   http://explicit_insecure.test: 9001 # serves over http only
 #
 bare: 9003
+bareOrigin: 9003/tcp
 bare.test: 9002
 invalid://failure: 9004
 valid.duplicate: 9000

--- a/pkg/config/example.upsert.yaml
+++ b/pkg/config/example.upsert.yaml
@@ -1,10 +1,11 @@
 # localias config file syntax
 #
-# 	alias: port
+# 	alias: port/optional origin schema
 #
 # for example,
 #
 #   bareTLD: 9003 # serves over https and http
+#   bareTLD: 9003/http # same as above but Origin header is set to http schema
 #   implicitly_secure.test: 9002 # serves over https and http
 #   https://explicit_secure.test: 9000 # serves over https and http
 #   http://explicit_insecure.test: 9001 # serves over http only

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/Integralist/go-findroot/find"
 	"github.com/adrg/xdg"
@@ -64,10 +67,27 @@ func Open(path string) (*Config, error) {
 	}
 	c := Config{Path: path}
 	for _, entry := range entries {
-		c.Set(Entry{
-			Alias: entry.Key.(string),
-			Port:  entry.Value.(int),
-		})
+		stringValue, ok := entry.Value.(string)
+		if ok && strings.Contains(stringValue, "/") {
+			split := strings.SplitN(stringValue, "/", 2)
+			port, err := strconv.Atoi(split[0])
+			if err != nil {
+				return nil, err
+			}
+			c.Set(Entry{
+				Alias:  entry.Key.(string),
+				Port:   port,
+				Origin: split[1],
+			})
+		} else {
+			c.Set(Entry{
+				Alias: entry.Key.(string),
+				Port:  entry.Value.(int),
+			})
+		}
+	}
+	for _, v := range c.Entries {
+		fmt.Printf("%s\n", v.String())
 	}
 	return &c, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -36,6 +36,7 @@ func (s *Server) StartCaddy() error {
 	// Start (or restart) the global Caddy service and load the current
 	// configuration.
 	cfgJSON, _, err := s.Config.CaddyJSON()
+	fmt.Println(string(cfgJSON))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
configuration is modified to support shema of origin, i.e. my_domain: 3000/http
the schema will be injected into Origin header

should be backwards compatible with old configurations

solves https://github.com/sveltejs/kit/issues/8026