### PR TITLE
feat: add caddyfile debug command

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,2 @@
+should take port :47145 = ALIAS
+and make sure to document that it uses a port

--- a/cmd/localias/debug/config.go
+++ b/cmd/localias/debug/config.go
@@ -13,6 +13,13 @@ var configFlags struct { //nolint:gochecknoglobals
 	Print *bool
 }
 
+func caddyImpl(_ *cobra.Command, _ []string) error {
+	cfg := shared.Config()
+	caddy := cfg.Caddyfile()
+	fmt.Println(caddy)
+	return nil
+}
+
 func configImpl(_ *cobra.Command, _ []string) error {
 	cfg := shared.Config()
 	if *configFlags.Print {
@@ -33,7 +40,14 @@ var configCmd = &cobra.Command{ //nolint:gochecknoglobals
 	RunE:  configImpl,
 }
 
+var caddyCmd = &cobra.Command{
+	Use:   "caddyfile",
+	Short: "show the Caddy configuration file used by localias",
+	RunE:  caddyImpl,
+}
+
 func init() {
 	configFlags.Print = configCmd.Flags().BoolP("print", "p", false, "print the contents of the config file")
 	Command.AddCommand(configCmd)
+	Command.AddCommand(caddyCmd)
 }


### PR DESCRIPTION
This PR adds a new `localias debug caddyfile` command to print the current generated Caddyfile config that is being used when you `localias run`. This is useful for debugging issues with that config. Hidden command shouldn't be used by most people but helpful for me when updating Caddy.

## Testing
- [x] `localias debug caddyfile` prints a valid config