### PR TITLE
feat: disable admin server

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,6 +135,7 @@ func (c Config) Caddyfile() string {
 	}
 	global := fmt.Sprintf(strings.TrimSpace(`
 {
+	admin off
 	persist_config off
 	local_certs
 	ocsp_stapling off


### PR DESCRIPTION
Following up @hslatman's comment on https://github.com/peterldowns/localias/pull/62, this PR completely disables the Caddy admin server. The previous PR stopped using it as a certificate issuer's `ask` endpoint, but this PR actually disables the server entirely.

## Testing
- [x] manually confirmed that `localias run` does NOT bind to port 2019

```console
$ localias start
...
$ localias status
daemon running with pid 29450
$ lsof -Pn | grep -E ':2019'
```
- [x] confirmed that proxying requests still seems to work correctly
- [x] confirmed that cert issuance for new aliases works correctly